### PR TITLE
Bugfix/2 correction flux événements + refactoring du point de terminaison de lecture de l'API

### DIFF
--- a/apps/of-api-gateway/src/main/java/org/ormi/priv/tfa/orderflow/api/gateway/productregistry/adapter/inbound/http/resource/ProductRegistryCommandResource.java
+++ b/apps/of-api-gateway/src/main/java/org/ormi/priv/tfa/orderflow/api/gateway/productregistry/adapter/inbound/http/resource/ProductRegistryCommandResource.java
@@ -31,6 +31,9 @@ import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRegistryEv
 import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRemoved;
 import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductUpdated;
 import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.config.ProductRegistryEventChannelName;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.query.config.ProductRegistryQueryChannelName;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message.ProductRegistryMessage;
+
 
 import io.quarkus.logging.Log;
 import io.smallrye.mutiny.Multi;
@@ -104,7 +107,7 @@ public class ProductRegistryCommandResource {
     // Create a stream of product registry events
     return Multi.createFrom().emitter(em -> {
       // Create consumer for product registry events with the given correlation id
-      final Consumer<ProductRegistryEvent> consumer = getEventsConsumerByCorrelationId(correlationId);
+      final Consumer<ProductRegistryMessage> consumer = getEventsConsumerByCorrelationId(correlationId);
       // Close the consumer on termination
       em.onTermination(() -> {
         try {
@@ -124,19 +127,22 @@ public class ProductRegistryCommandResource {
               Log.debug("No event received within timeout of " + timeout + " seconds.");
               em.complete();
             }
-            final ProductRegistryEvent evt = msg.get().getValue();
-            Log.debug("Received event: " + evt);
-            // Map event to DTO
-            if (evt instanceof ProductRegistered registered) {
-              Log.debug("Emitting DTO for registered event: " + registered);
-              // Emit DTO for registered event
-              em.emit(ProductRegistryEventDtoMapper.INSTANCE.toDto(registered));
-            } else {
+            if (msg.get().getValue() instanceof ProductRegistryError){
               // Fail the stream on unexpected event types
               Throwable error = new ProductRegistryEventStreamException("Unexpected event type: " + evt.getClass().getName());
               em.fail(error);
               return;
             }
+
+            final ProductRegistryEvent evt = msg.get().getValue();
+              Log.debug("Received event: " + evt);
+              // Map event to DTO
+              if (evt instanceof ProductRegistered registered) {
+                Log.debug("Emitting DTO for registered event: " + registered);
+                // Emit DTO for registered event
+                em.emit(ProductRegistryEventDtoMapper.INSTANCE.toDto(registered));
+              }
+
             // Acknowledge the message
             consumer.acknowledge(msg.get());
           } catch (PulsarClientException e) {
@@ -323,14 +329,16 @@ public class ProductRegistryCommandResource {
    * @param correlationId - correlation id to use for the consumer
    * @return Consumer for product registry events
    */
-  private Consumer<ProductRegistryEvent> getEventsConsumerByCorrelationId(String correlationId) {
+
+  // changer pour que ça renvoie un ProductRegistryMessage
+  private Consumer<ProductRegistryMessage> getEventsConsumerByCorrelationId(String correlationId) {
     try {
       // Define the channel name, topic and schema for the consumer
-      final String channelName = ProductRegistryEventChannelName.PRODUCT_REGISTRY_EVENT.toString();
+      final String channelName = ProductRegistryQueryChannelName.PRODUCT_REGISTRY_READ_RESULT.toString(); // changement pour pointer vers le coté lecture
       final String topic = channelName + "-" + correlationId;
       // Create and return the subscription (consumer)
       return pulsarClients.getClient(channelName)
-          .newConsumer(Schema.JSON(ProductRegistryEvent.class))
+          .newConsumer(Schema.JSON(ProductRegistryMessage.class))
           .subscriptionName(topic)
           .topic(topic)
           .subscribe();

--- a/apps/of-api-gateway/src/main/resources/application.properties
+++ b/apps/of-api-gateway/src/main/resources/application.properties
@@ -23,3 +23,6 @@ mp.messaging.incoming.product-registry-event.subscriptionType=Shared
 # Pulsar dev service
 quarkus.pulsar.devservices.enabled=true
 quarkus.pulsar.devservices.image-name=apachepulsar/pulsar:3.2.4
+
+# Timeouts
+event.timeout=10

--- a/apps/of-product-registry-microservices/product.registry.read/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/read/service/ProductRegistryEventConsumer.java
+++ b/apps/of-product-registry-microservices/product.registry.read/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/read/service/ProductRegistryEventConsumer.java
@@ -2,7 +2,9 @@ package org.ormi.priv.tfa.orderflow.product.registry.read.service;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRegistryEvent;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message.ProductRegistryMessage;
 import org.ormi.priv.tfa.orderflow.product.registry.read.projection.ProductRegistryProjector;
+import org.ormi.priv.tfa.orderflow.product.registry.read.service.producer.ProductRegistryEventSinker;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -14,11 +16,22 @@ public class ProductRegistryEventConsumer {
   @Inject
   private ProductRegistryProjector projector;
 
+  @Inject
+  private ProductRegistryEventSinker sinker;
+
   @Incoming("product-registry-event")
   @Transactional(Transactional.TxType.REQUIRED)
-  public void handleEvent(ProductRegistryEvent event) {
+  public void handleEvent(ProductRegistryMessage message) {
+    final ProductRegistryEvent event = msg.get().getValue()
+    
     // Project the event
     projector.handleEvent(event);
+
     // TODO: Sink the event here once or while projection is processed
+    // Get the correlation id from the message metadata
+    final var metadata = msg.getMetadata(PulsarIncomingMessageMetadata.class).orElseThrow();
+    final String correlationId = Optional.ofNullable(metadata.getProperty("correlation-id")).orElseThrow();
+    sinker.sink(correlationID, event)
+
   }
 }

--- a/apps/of-product-registry-microservices/product.registry.read/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/read/service/producer/ProductRegistryEventSinker.java
+++ b/apps/of-product-registry-microservices/product.registry.read/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/read/service/producer/ProductRegistryEventSinker.java
@@ -1,0 +1,85 @@
+package org.ormi.priv.tfa.orderflow.product.registry.read.service.producer;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRegistered;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRegistryEvent;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRemoved;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductUpdated;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.config.ProductRegistryEventChannelName;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.query.config.ProductRegistryQueryChannelName;
+
+import io.quarkus.logging.Log;
+import io.smallrye.reactive.messaging.pulsar.PulsarClientService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * The product registry event sinker.
+ * Produces events to the product registry event channel so it can be watched on
+ * other services.
+ */
+@ApplicationScoped
+public class ProductRegistryEventSinker {
+
+  /**
+   * The Pulsar client service.
+   */
+  @Inject
+  private PulsarClientService pulsarClients;
+
+  /**
+   * Produce the given event with the given correlation id.
+   * 
+   * @param correlationId - the correlation id
+   * @param event         - the event
+   */
+  public void sink(String correlationId, ProductRegistryEvent event) {
+    // Get the producer for the correlation id
+    getEventSinkByCorrelationId(correlationId)
+        .thenAccept((producer) -> {
+          // Sink the event
+          producer
+              .newMessage()
+              .value(event)
+              .sendAsync()
+              .whenComplete((msgId, ex) -> {
+                if (ex != null) {
+                  throw new NoProduceEventWithIdException("Failed to produce event for correlation id: " + correlationId, ex);
+                }
+                Log.debug(String.format("Sinked event with correlation id{%s} in msg{%s}", correlationId, msgId));
+                try {
+                  producer.close();
+                } catch (PulsarClientException e) {
+                  throw new UnableToCloseProducerException("Failed to close producer", e);
+                }
+              });
+        });
+  }
+
+  /**
+   * Create a producer for the given correlation id.
+   * 
+   * @param correlationId - the correlation id
+   * @return the producer
+   */
+  private CompletionStage<Producer<ProductRegistryMessage>> getEventSinkByCorrelationId(String correlationId) {
+    // Define the channel name, topic and schema definition
+    final String channelName = ProductRegistryQueryChannelName.PRODUCT_REGISTRY_READ_RESULT.toString();
+    final String topic = channelName + "-" + correlationId;
+    // Create and return the producer
+    return pulsarClients.getClient(channelName)
+        .newProducer(Schema.JSON(ProductRegistryMessage.class))
+        .producerName(topic)
+        .topic(topic)
+        .createAsync()
+        .exceptionally(ex -> {
+          throw new UnableToCreateProducerException("Failed to create producer for correlation id: " + correlationId, ex);
+        });
+  }
+}

--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/service/consumer/ProductRegistryCommandConsumer.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/service/consumer/ProductRegistryCommandConsumer.java
@@ -80,7 +80,7 @@ public class ProductRegistryCommandConsumer {
         .subscribeAsCompletionStage()
         .thenAccept(evt -> {
           // Produce event on correlated bus
-          eventProducer.sink(correlationId, evt);
+           //eventProducer.sink(correlationId, evt);
           Log.debug(String.format("Acknowledge command: %s", cmd.getClass().getName()));
           msg.ack();
         }).exceptionallyCompose(e -> {

--- a/libs/shared/build.gradle
+++ b/libs/shared/build.gradle
@@ -10,27 +10,10 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation 'io.quarkus:quarkus-arc'
-    implementation 'io.quarkus:quarkus-rest-jackson'
-    implementation 'io.quarkus:quarkus-hibernate-validator'
-    implementation 'io.quarkus:quarkus-messaging-pulsar'
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"
-    implementation project(':libs-event-sourcing')
-    implementation project(':libs-published-language')
-
-    // SmallRye OpenAPI
-    implementation 'io.quarkus:quarkus-smallrye-openapi'
-
-    // shared library
-    implementation project(':libs/shared')
 
     // MapStruct build-time annotation processor
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
-
-    testImplementation 'io.quarkus:quarkus-junit5'
-    testImplementation 'io.quarkus:quarkus-junit5-mockito'
-    testImplementation 'io.quarkus:quarkus-jacoco'
 
     testImplementation("${junitJupiterGroupId}:${junitJupiterArtifactId}:${junitJupiterVersion}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
@@ -38,7 +21,7 @@ dependencies {
     testRuntimeOnly("${junitJupiterGroupId}:${junitJupiterArtifactId}-engine:${junitJupiterVersion}")
 }
 
-group 'org.ormi.priv.tfa.orderflow'
+group 'org.ormi.priv.tfa.shared'
 version '1.0.0-SNAPSHOT'
 
 java {

--- a/libs/shared/src/main/java/org/ormi/priv/tfa/orderflow/lib/shared/AbstractEventStream.java
+++ b/libs/shared/src/main/java/org/ormi/priv/tfa/orderflow/lib/shared/AbstractEventStream.java
@@ -1,0 +1,45 @@
+package org.ormi.priv.tfa.orderflow.lib.shared;
+
+
+public class StreamAbstract {
+
+    public static <T> void consumeEventStream(
+        Consumer<T> consumer,
+        int timeout,
+        MultiEmitter<T> em
+    ){
+        while(!em.isCancelled()) {
+          try {
+            final var timeout;
+            final var msg = Optional.ofNullable(consumer.receive(timeout, TimeUnit.MILLISECONDS));
+            if (msg.isEmpty()) {
+              // Complete the emitter if no event is received within the timeout. Free up resources.
+              Log.debug("No event received within timeout of " + timeout + " seconds.");
+              em.complete();
+            }
+            if (msg.get().getValue() instanceof ProductRegistryError){
+              // Fail the stream on unexpected event types
+              Throwable error = new ProductRegistryEventStreamException("Unexpected event type: " + evt.getClass().getName());
+              em.fail(error);
+              return;
+            }
+
+            final ProductRegistryEvent evt = msg.get().getValue();
+              Log.debug("Received event: " + evt);
+              // Map event to DTO
+              if (evt instanceof ProductRegistered registered) {
+                Log.debug("Emitting DTO for registered event: " + registered);
+                // Emit DTO for registered event
+                em.emit(ProductRegistryEventDtoMapper.INSTANCE.toDto(registered));
+              }
+
+            // Acknowledge the message
+            consumer.acknowledge(msg.get());
+          } catch (PulsarClientException e) {
+            Log.error("Failed to receive event from consumer.", e);
+            em.fail(e);
+            return;
+          }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,3 +41,8 @@ project(':libs-published-language').projectDir =
 include(':libs-event-sourcing')
 project(':libs-event-sourcing').projectDir =
   new File('libs/event-sourcing')
+
+include(':libs-shared')
+project(':libs-shared').projectDir =
+  new File('libs/shared')
+  


### PR DESCRIPTION
# Flux d'événements

Correction du flux des évènements. Le point de terminaison de lecture de l'API pointe maintenant sur le coté lecture de l'application. L'écriture n'envoie plus d'évènement et c'est le coté lecture qui a cette responsabilité.

# Refactoring

Le délai d'attente n'est plus initialisé de façon brut mais est maintenant une propriété d'application de l'API gateway.  
Réduction de la complexité du consume event et déplacement dans une nouvelle classe partagé dans les libs.

