### PR TITLE
Tâche 3 : Convertir les payloads des Entités (couche de persistance) en records

### DIFF
--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRegisteredEventEntity.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRegisteredEventEntity.java
@@ -9,19 +9,7 @@ public class ProductRegisteredEventEntity extends ProductRegistryEventEntity {
   /**
    * Payload for the event.
    */
-  public static class Payload {
-    /**
-     * The id of the product.
-     */
-    public String productId;
-    /**
-     * The name of the product.
-     */
-    public String name;
-    /**
-     * The description of the product.
-     */
-    public String productDescription;
+  public static record Payload(String productId, String name, String productDescription) {
   }
 
   /**

--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRemovedEventEntity.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRemovedEventEntity.java
@@ -1,19 +1,15 @@
 package org.ormi.priv.tfa.orderflow.product.registry.aggregate.repository.model;
 
 /**
-     * Event entity for a product which is removed
-     */
+ * Event entity for a product which is removed
+ */
 public class ProductRemovedEventEntity extends ProductRegistryEventEntity {
   static final String EVENT_TYPE = "ProductRemoved";
 
   /**
    * Payload for the event.
    */
-  public static class Payload {
-    /**
-     * The id of the product.
-     */
-    public String productId;
+  public static record Payload(String productId) {
   }
 
   /**
@@ -25,5 +21,4 @@ public class ProductRemovedEventEntity extends ProductRegistryEventEntity {
   public String getEventType() {
     return EVENT_TYPE;
   }
-  
 }

--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductUpdatedEventEntity.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductUpdatedEventEntity.java
@@ -1,34 +1,21 @@
 package org.ormi.priv.tfa.orderflow.product.registry.aggregate.repository.model;
 
 /**
-     * Event entity for a product which is updated
-     */
+ * Event entity for a product which is updated
+ */
 public class ProductUpdatedEventEntity extends ProductRegistryEventEntity {
   static final String EVENT_TYPE = "ProductUpdated";
 
   /**
    * Payload for the event.
    */
-  public static class Payload {
-    /**
-     * The id of the product.
-     */
-    public String productId;
-    /**
-     * The name of the product.
-     */
-    public String name;
-    /**
-     * The description of the product.
-     */
-    public String productDescription;
+  public static record Payload(String productId, String name, String productDescription) {
   }
 
   /**
    * The payload for the event.
    */
   public Payload payload;
-
 
   @Override
   public String getEventType() {


### PR DESCRIPTION
Amélioration de la la qualité du code dans le microservice de registre de produits en remplaçant les classes utilisées pour les payloads des entités par des records.

Avantages :

1. Simplification et réduction du code boilerplate.
2. Garantie d'immutabilité pour les données des payloads.
3. Facilitation des tests et de la maintenance du code.