### PR TITLE
Tâche 4 : Modifier les Entités (couche de persistance) pour utiliser des champs privés avec des accesseurs

### DIFF
--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRegisteredEventEntity.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRegisteredEventEntity.java
@@ -15,7 +15,25 @@ public class ProductRegisteredEventEntity extends ProductRegistryEventEntity {
   /**
    * The payload for the event.
    */
-  public Payload payload;
+  private Payload payload;
+
+  /**
+   * Get the payload for the event.
+   *
+   * @return The payload for the event.
+   */
+  public Payload getPayload() {
+    return payload;
+  }
+
+  /**
+   * Set the payload for the event.
+   *
+   * @param payload The payload for the event.
+   */
+  public void setPayload(Payload payload) {
+    this.payload = payload;
+  }
 
   @Override
   public String getEventType() {

--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRemovedEventEntity.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductRemovedEventEntity.java
@@ -15,7 +15,25 @@ public class ProductRemovedEventEntity extends ProductRegistryEventEntity {
   /**
    * The payload for the event.
    */
-  public Payload payload;
+  private Payload payload;
+
+  /**
+   * Get the payload for the event.
+   *
+   * @return The payload for the event.
+   */
+  public Payload getPayload() {
+    return payload;
+  }
+
+  /**
+   * Set the payload for the event.
+   *
+   * @param payload The payload for the event.
+   */
+  public void setPayload(Payload payload) {
+    this.payload = payload;
+  }
 
   @Override
   public String getEventType() {

--- a/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductUpdatedEventEntity.java
+++ b/apps/of-product-registry-microservices/product.registry/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/aggregate/repository/model/ProductUpdatedEventEntity.java
@@ -15,7 +15,25 @@ public class ProductUpdatedEventEntity extends ProductRegistryEventEntity {
   /**
    * The payload for the event.
    */
-  public Payload payload;
+  private Payload payload;
+
+  /**
+   * Get the payload for the event.
+   *
+   * @return The payload for the event.
+   */
+  public Payload getPayload() {
+    return payload;
+  }
+
+  /**
+   * Set the payload for the event.
+   *
+   * @param payload The payload for the event.
+   */
+  public void setPayload(Payload payload) {
+    this.payload = payload;
+  }
 
   @Override
   public String getEventType() {


### PR DESCRIPTION
Cette PR vise à améliorer la qualité et l'encapsulation du code dans le microservice de registre de produits en modifiant les entités de la couche de persistance pour utiliser des champs privés avec des accesseurs.

Changement de la visibilité des champs 

Avantages attendus :

1. Renforcement de l'encapsulation en limitant l'accès direct aux champs.
2. Amélioration de la maintenabilité et de la sécurité du code.
3. Conformité aux bonnes pratiques en Java pour la gestion des entités.